### PR TITLE
Feature/yihua/fix topic lifecycle validation

### DIFF
--- a/main/apps/metadata_mgt/actors/ConversationManager.py
+++ b/main/apps/metadata_mgt/actors/ConversationManager.py
@@ -213,3 +213,51 @@ class ConversationManager():
                 "status": False,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
+        
+    @csrf_exempt
+    @require_http_methods(["POST"])
+    @log_trigger()
+    def verify_conversation_exist(request):
+        """
+        Input (POST JSON):
+            {
+                "conversation_uid": <string>
+            }
+
+        Output (JsonResponse):
+            {
+                "status_code": <int>,
+                "message": <string>
+            }
+        """
+        try:
+            payload = json.loads(request.body)
+
+            # 檢查必填欄位
+            if "conversation_uid" not in payload:
+                return JsonResponse({
+                    "status": False,
+                    "message": "缺少必填欄位: conversation_uid"
+                }, status=400)
+
+            # 呼叫 Controller
+            response = ConversationController.get_conversation(
+                conversation_uid=payload["conversation_uid"]
+            )
+
+            # 從 Controller 回傳的資料只取 status、message 即可
+            return JsonResponse({
+                "status": response["status"],
+                "message": response["message"]
+            }, status=response["status_code"])
+
+        except json.JSONDecodeError:
+            return JsonResponse({
+                "status": False,
+                "message": "無效的 JSON 格式"
+            }, status=400)
+        except Exception as e:
+            return JsonResponse({
+                "status": False,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
+            }, status=500)

--- a/main/apps/metadata_mgt/api/urls.py
+++ b/main/apps/metadata_mgt/api/urls.py
@@ -14,6 +14,7 @@ urlpatterns = [
     path('metadata_mgt/ConversationManager/get_conversation_metadata', ConversationManager.get_conversation_metadata,name='get_conversation_metadata'),
     path('metadata_mgt/ConversationManager/update_conversation_name', ConversationManager.update_conversation_name,name='update_conversation_name'),    
     path('metadata_mgt/ConversationManager/delete_conversation_metadata', ConversationManager.delete_conversation_metadata,name='delete_conversation_metadata'),
+    path('metadata_mgt/ConversationManager/verify_conversation_exist', ConversationManager.verify_conversation_exist,name='verify_conversation_exist'),
     path('metadata_mgt/TextManager/create_text_metadata', TextManager.create_text_metadata,name='create_text_metadata'),
     path('metadata_mgt/TextManager/get_text_metadata', TextManager.get_text_metadata,name='get_text_metadata'),
     path('metadata_mgt/TextManager/delete_text_metadata', TextManager.delete_text_metadata,name='delete_text_metadata'),

--- a/main/apps/topic_mgt/actors/Broker.py
+++ b/main/apps/topic_mgt/actors/Broker.py
@@ -39,24 +39,23 @@ class Broker(AsyncWebsocketConsumer):
 				
             conversation_uid = payload["conversation_uid"]
         
-			# # (2) 呼叫 metadata_mgt 以確認 conversation 存在
-            # try:
-            #     resp = json_request(
-            #         module="metadata_mgt",
-            #         actor="ConversationManager",
-            #         function="verify_conversation_exist",
-            #         payload=payload,
-            #     )
-            #     meta_data = resp.json()
-            # except Exception as e:
-            #     return JsonResponse({
-            #         "status_code": 502,
-            #         "message": f"Fail to call metadata_mgt API (verify_conversation_exist): {str(e)}"
-            #     }, status=502)
+			# (2) 呼叫 metadata_mgt 以確認 conversation 存在
+            try:
+                resp = json_request(
+                    module="metadata_mgt",
+                    actor="ConversationManager",
+                    function="verify_conversation_exist",
+                    payload=payload,
+                )
+                meta_data = resp.json()
+            except Exception as e:
+                return JsonResponse({
+                    "status_code": 502,
+                    "message": f"Fail to call metadata_mgt API (verify_conversation_exist): {str(e)}"
+                }, status=502)
             
-			# # ==還需要更改==
-            # if not meta_data.get("status", False):
-            #     return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
+            if not meta_data.get("status", False):
+                return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
             
 			# (3) 註冊 topic
             broker = ServiceBroker()
@@ -116,11 +115,19 @@ class Broker(AsyncWebsocketConsumer):
         await self.accept()
         self.broker = ServiceBroker()
 
-        # # 3) 驗證 topic 是否已註冊
-        # exists = self.broker.topic_exists(self.conversation_uid)
-        # if not exists: 
-        #     await self.close(code=4003, reason="conversation_uid not exist.")
-        #     return
+        # 3) 驗證 topic 是否已註冊
+        exists = self.broker.topic_exists(self.conversation_uid)
+        if not exists: 
+            await self.close(code=4003, reason="conversation_uid not exist.")
+            await async_log_writer(
+                log_level="ERROR",
+                status_code="1000",
+                source_type="Websocket",
+                func=self.connect,
+                args=[self],
+                message="conversation_uid not registe"
+            )
+            return
     
         # 4) 訂閱 topic
         self.broker.subscribe(self.conversation_uid, self.group_name)
@@ -136,8 +143,8 @@ class Broker(AsyncWebsocketConsumer):
 
     async def disconnect(self, code):
         # 1) 取消訂閱 topic
-        self.broker.unsubscribe(self.conversation_uid, self.group_name)
         await self.channel_layer.group_discard(self.group_name, self.channel_name)
+        self.broker.unsubscribe(self.conversation_uid, self.group_name)
         await async_log_writer(
             log_level="INFO",
             status_code="200",
@@ -145,7 +152,23 @@ class Broker(AsyncWebsocketConsumer):
             func=self.disconnect,
             args=[self],
             message="WebSocket disconnect success"
+        ) 
+
+    async def force_disconnect(self, event):
+        """
+        Receives a force disconnect message from the channel layer and closes the current WebSocket connection.
+        This method name 'force_disconnect' must match the 'type' in group_send.
+        """
+        reason = event.get("reason", "Topic was deleted by admin.")
+        await async_log_writer(
+            log_level="INFO",
+            status_code="200",
+            source_type="Websocket",
+            func=self.force_disconnect,
+            args=[self],
+            message=f"Received force disconnect signal for topic: {self.conversation_uid}. Reason: {reason}"
         )
+        await self.close(code=4004, reason=reason)
 
     # -------- WebSocket 進來的資料（前端或其他 WS Client） --------
     @text_decorator(role="user")

--- a/main/apps/topic_mgt/services/broker.py
+++ b/main/apps/topic_mgt/services/broker.py
@@ -19,6 +19,7 @@ class Broker:
             password=settings.REDIS_PASSWORD,
             db=settings.REDIS_DB
         )
+        self.channel_layer = get_channel_layer() 
 
     def _topic_key(self, conversation_uid: str) -> str:
         """
@@ -38,6 +39,14 @@ class Broker:
         """
         刪除一個對應 conversation_uid 的 Set。
         """
+        group_name = f"topic_{conversation_uid}"
+        async_to_sync(self.channel_layer.group_send)(
+            group_name,
+            {
+                "type": "force_disconnect", 
+                "reason": f"Topic '{conversation_uid}' has been deleted. Disconnecting all clients."
+            }
+        )
         key = self._topic_key(conversation_uid)
         self._redis.delete(key)
 


### PR DESCRIPTION
## 🚀 目的 / Motivation
為了 **完整 websocket 生命週期**，本次 PR：
1. 新增 `verify_conversation_exist()`，在註冊 topic 前驗證對話存在
2. 加強 websocket 註冊、連線、斷線流程


## 📝 主要變更 / What’s Changed
- **新增 `verify_conversation_exist()`**
  
- **Broker.py**
  - 註冊 topic 前驗證對話存在
  - 連線前驗證是否註冊成功
  - 斷線後移除 topic 註冊紀錄
  - 新增 `force_disconnect()` 以強制斷線

- **broker.py**
  - 刪除對話後透過 `force_disconnect()` 強制斷線


## ✅ 如何測試 / How to Test
1. 確保 `itri-net` 已存在，不存在則執行
`docker network create itri-net`

2. 新增腳本 `run_all.sh`
    ```shell
    #!/bin/bash
    
    # 宣告 network
    NETWORK=itri-net
    IMAGE=itri-intent-backend
    
    function remove_container_if_exists() {
      local container_name="$1"
      if [ "$(docker ps -aq -f name=${container_name})" ]; then
        echo "Stopping and removing existing container: ${container_name}"
        docker stop "${container_name}" 2>/dev/null
        docker rm "${container_name}" 2>/dev/null
      fi
    }
    
    function remove_image_if_exists () {
      local image="$1"
      if docker images -q "${image}" | grep -q .; then
        echo "Removing old image ${image}"
        docker rmi -f "${image}" >/dev/null
      fi
    }
    
    remove_container_if_exists "itri-intent-backend"
    remove_container_if_exists "itri-intent-worker"
    remove_container_if_exists "intent-postgres-db"
    remove_container_if_exists "intent-redis-db"
    remove_container_if_exists "intent-pgadmin"
    remove_image_if_exists "${IMAGE}"
    
    
    source .env
    
    # 啟動 Postgres 容器
    docker run --network $NETWORK --name intent-postgres-db \
        -e POSTGRES_PASSWORD=$HTTP_POSTGRES_DATABASE_PASSWORD \
        -e POSTGRES_USER=$HTTP_POSTGRES_DATABASE_HOST_USER \
        -p $HTTP_POSTGRES_DATABASE_HOST_PORT:$HTTP_POSTGRES_DATABASE_HOST_PORT \
        -v ~/postgres_data:/var/lib/postgresql/data \
        -d postgres:latest
    
    sleep 5
    
    # 建立資料庫
    docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -c "CREATE DATABASE intent;"
    
    # 檢查資料庫列表
    # docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -l
    
    # 啟動 pgAdmin 容器
    docker run --network $NETWORK --name intent-pgadmin \
        -e PGADMIN_DEFAULT_EMAIL=$HTTP_PGADMIN_EMAIL \
        -e PGADMIN_DEFAULT_PASSWORD=$HTTP_PGADMIN_PASSWORD \
        -p $HTTP_PGADMIN_HOST_PORT:80 \
        -d dpage/pgadmin4
      
    #啟動 Redis 容器 
    docker run --network $NETWORK --name intent-redis-db \
      -e REDIS_USER=$HTTP_REDIS_DATABASE_HOST_USER \
      -e REDIS_PASSWORD=$HTTP_REDIS_DATABASE_PASSWORD \
      -p $HTTP_REDIS_DATABASE_HOST_PORT:$HTTP_REDIS_DATABASE_HOST_PORT \
      -d redis \
      sh -c 'echo "databases 16" > /tmp/redis.conf && \
             echo "user $REDIS_USER on >$REDIS_PASSWORD ~* +@all" >> /tmp/redis.conf && \
             redis-server /tmp/redis.conf'
             
    #包專案image
    docker build --no-cache -t itri-intent-backend ./
    
    # 啟動 意圖後端系統 容器
    docker run -d --network $NETWORK \
        --name itri-intent-backend \
        -p $HTTP_WORKFLOW_MGT_PORT:$HTTP_WORKFLOW_MGT_PORT \
        itri-intent-backend \
        sh -c "
          python manage.py migrate --noinput &&
          daphne -b 0.0.0.0 -p $HTTP_WORKFLOW_MGT_PORT main.asgi:application
        "
    
    # 啟動 意圖後端系統 Channels Worker 監聽 ChannelNameRouter
    docker run -d --network $NETWORK \
      --name itri-intent-worker \
      --env-file .env \
      itri-intent-backend \
      bash -c "source .env && python manage.py runworker consumer"
    ```

4. 跑佈署腳本
    ```shell
	chmod 777 run.sh
    ./run_all.sh
	```

5. 如果遇到 `/media` 權限問題，需手動設定權限


## 📜 測試項目 / Test Case

### 從前端操作須符合

1. 註冊
2. 登入
3. 獲取對話清單
5. 創建對話，並會自動生成標題
	- 輸入文本`查詢整體UE狀態`需顯示表格
	- 輸入文本`查詢SINR Map`需顯示圖片
	- 輸入文本`預測干擾抑制演算法`需顯示表格
	- 輸入文本`執行干擾抑制演算法`需顯示表格
	- 輸入文本`停用干擾抑制演算法`需顯示表格
6. 修改對話名稱
7. 刪除對話


### 從後端操作須符合

1. 正常解析不同來源，包括`system`, `Websocket`, `dify engine`
2. 狀態碼解析正常，不會出現定義之外狀況
3. 錯誤訊息能正常顯示
4. 正常記錄所有執行動作
5. 創建對話，redis 有相關紀錄
7. 刪除對話，redis 不會有該 topic 存在
