### PR TITLE
Feature/yihua/fix ws payload and workflow status

### DIFF
--- a/main/apps/metadata_mgt/actors/WorkflowManager.py
+++ b/main/apps/metadata_mgt/actors/WorkflowManager.py
@@ -42,8 +42,8 @@ class WorkflowManager:
 
             # 2) 取出參數，若沒給則使用預設
             conversation_uid = payload["conversation_uid"]
-            workflow_step = payload.get("workflow_step", "text_analysis")
-            workflow_status = payload.get("workflow_status", "Start")
+            workflow_step = payload.get("workflow_step", "A")
+            workflow_status = payload.get("workflow_status", "1")
 
             # 3) 呼叫 Controller 建立
             result = WorkflowController.create_workflow(

--- a/main/apps/workflow_mgt/actors/Producer.py
+++ b/main/apps/workflow_mgt/actors/Producer.py
@@ -25,7 +25,7 @@ class Producer:
         try:
             # (1) 檢查必填欄位
             payload = json.loads(request.body)
-            required_fields = ["conversation_uid", "text_content"]
+            required_fields = ["event_type", "conversation_uid", "text_content"]
             missing_fields = [f for f in required_fields if f not in payload]
             if missing_fields:
                 return JsonResponse({

--- a/main/apps/workflow_mgt/actors/WorkflowManager.py
+++ b/main/apps/workflow_mgt/actors/WorkflowManager.py
@@ -43,6 +43,27 @@ class WorkflowManager:
                 user_content = text_content[0].get("content", "") 
             else:
                 user_content = "" # 或自行定義預設行為 
+                
+            # 更新 workflow status 1
+            work_payload = {
+                "conversation_uid": conversation_uid,
+                "workflow_status": "1"
+            }
+
+            try:
+                resp = json_request(
+                    module="workflow_mgt",
+                    actor="WorkflowManager",
+                    function="update_workflow_status",
+                    payload=work_payload,
+                )
+                work_data = resp.json()
+            except Exception as e:
+                print("Workflow 更新失敗: ", e)
+
+            # 檢查後端回傳是否成功
+            if not work_data.get("status_code", 400):
+                return JsonResponse(work_data, status_code=work_data.get("status_code", 400))
 
             # (2) 呼叫 dify 執行工作流
             result = dify_single_intent_workflow(conversation_uid, user_content)
@@ -112,23 +133,13 @@ class WorkflowManager:
                     "message": f"Fail to call metadata_mgt API (get_workflow_metadata): {str(e)}"
                 }, status=502)
 
-            # 檢查後端回傳是否成功 ==還需要更改==
+            # 檢查後端回傳是否成功
             if not meta_data.get("status", False):
-                return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
-
-            # 從回傳資料中取出 step, status
-            workflow_info = meta_data.get("data", {})
-            workflow_step = workflow_info.get("workflow_step", "demo")
-
-            # (3) 根據 step 呼叫對應函式
-            result = dify_single_intent_workflow(conversation_uid=conversation_uid,user_prompt=content)
-
-            text_data = result.get("parsed_data","")
+                return JsonResponse(meta_data, status_code=meta_data.get("status_code", 400))
 
             return JsonResponse({
-                    "event_type": workflow_step,
-                    "conversation_uid": conversation_uid,
-                    "text": text_data
+                "status_code": 200,
+                "message": "Workflow 更新成功"
             })
 
         except Exception as e:

--- a/main/apps/workflow_mgt/actors/WorkflowManager.py
+++ b/main/apps/workflow_mgt/actors/WorkflowManager.py
@@ -97,7 +97,7 @@ class WorkflowManager:
         try:
             # (1) 檢查必填欄位
             payload = json.loads(request.body)
-            required_fields = ["conversation_uid", "workflow_step", "workflow_status"]
+            required_fields = ["conversation_uid", "workflow_status"]
             missing_fields = [f for f in required_fields if f not in payload]
             if missing_fields:
                 return JsonResponse({
@@ -106,13 +106,12 @@ class WorkflowManager:
                 }, status=400)
 			
             conversation_uid = payload["conversation_uid"]
-            workflow_step = payload["workflow_step"]
             workflow_status = payload["workflow_status"]
             
             # (2) 呼叫 metadata_mgt 以更新 workflow step & status
             meta_payload = {
                 "conversation_uid": conversation_uid,
-                "workflow_step": workflow_step,
+                "workflow_step": payload.get("workflow_step"),
                 "workflow_status": workflow_status,
                 "start_time": payload.get("start_time"),
                 "end_time": payload.get("end_time"),

--- a/main/apps/workflow_mgt/services/workflows.py
+++ b/main/apps/workflow_mgt/services/workflows.py
@@ -126,6 +126,24 @@ def dify_single_intent_workflow(conversation_uid,user_prompt):
             timeout=60,
             stream=True
         )
+
+        # 更新 workflow step & status 2
+        work_payload = {
+            "conversation_uid": conversation_uid,
+            # "workflow_step": "A",
+            "workflow_status": "2"
+        }
+
+        try:
+            resp = json_request(
+                module="workflow_mgt",
+                actor="WorkflowManager",
+                function="update_workflow_status",
+                payload=work_payload,
+            )
+        except Exception as e:
+            print("Workflow 更新失敗: ", e)
+
         # 2. 處理串流回應
         client = SSEClient(response)
         for event in client.events():
@@ -148,6 +166,7 @@ def dify_single_intent_workflow(conversation_uid,user_prompt):
                         text = image_url
                         full_download_url = f"http://{host}{image_url}"
                         work_payload = {
+                            "event_type": "2",
                             "conversation_uid": conversation_uid,
                             "text_content": [{
                                 "type": "image",
@@ -157,6 +176,7 @@ def dify_single_intent_workflow(conversation_uid,user_prompt):
                     else:
                         text = answer
                         work_payload = {
+                            "event_type": "2",
                             "conversation_uid": conversation_uid,
                             "text_content": [{
                                 "type": "message",
@@ -203,6 +223,45 @@ def dify_single_intent_workflow(conversation_uid,user_prompt):
                     args=None,
                     message=ans_text
                 )
+            
+            # 更新 workflow step & status 3
+            work_payload = {
+                "conversation_uid": conversation_uid,
+                # "workflow_step": "A",
+                "workflow_status": "3"
+            }
+
+            try:
+                resp = json_request(
+                    module="workflow_mgt",
+                    actor="WorkflowManager",
+                    function="update_workflow_status",
+                    payload=work_payload,
+                )
+                work_data = resp.json()
+            except Exception as e:
+                print("Workflow 更新失敗: ", e)
+
+            work_payload = {
+                "event_type": "3",
+                "conversation_uid": conversation_uid,
+                "text_content": [{
+                    "type": "message",
+                    "content": "Finish workflow"
+                }],
+            }
+
+            try:
+                resp = json_request(
+                    module="workflow_mgt",
+                    actor="Producer",
+                    function="dispatch_topic",
+                    payload=work_payload,
+                )
+                print("推播成功:", resp)
+            except Exception as e:
+                print("推播失敗:", e)
+
             return {
                 "status": True,
                 "message": "成功取得資料",

--- a/main/utils/TextDecorator.py
+++ b/main/utils/TextDecorator.py
@@ -45,12 +45,14 @@ def text_decorator(role: str):
                     event = args[0]
                 if event:
                     payload = event.get("payload", {})
+                    event_type = payload.get("event_type", "")
                     text_content = payload.get("text_content", [])
+
+                    if "3" in event_type:
+                        return await func(self, *args, **kwargs)
 
             # # ---- 若取得 text_dict，嘗試取得 text_content ----
             # # 例： text_dict = { "text_content": [ { "type": "text", "content": "..." } ] }
-            # if isinstance(text_dict, dict):
-            #     text_content = text_dict.get("text_content", None)
             if text_content is not None:
                 create_payload = {
                     "conversation_uid": conversation_uid,
@@ -89,7 +91,10 @@ def text_decorator(role: str):
                                     if "event" in kwargs:
                                         kwargs["event"]["payload"]["text_content"] = updated_text_content
                                     else:
-                                        args = ({"payload": {"text_content": updated_text_content}},) + tuple(args[1:])
+                                        if args and isinstance(args[0], dict) and "payload" in args[0]:
+                                            new_payload = args[0]["payload"].copy()
+                                            new_payload["text_content"] = updated_text_content
+                                            args = ({"payload": new_payload, **{k:v for k,v in args[0].items() if k!="payload"}},) + args[1:]
                                 break
 
                 except Exception as e:


### PR DESCRIPTION
## 🚀 目的 / Motivation
為了 **完整 workflow status 生命週期**，並 **通知前端完成 workflow**，本次 PR：
1. 新增 `event_type` 至 websocket payload
2. 修正 `update_workflow_status()` 流程
3. workflow 執行時更新 status 狀態並回傳前端


## 📝 主要變更 / What’s Changed
- **Producer.dispatch_topic() 新增 `event_type`**
  
- **更新 workflow_status 狀態**
  - workflow_status 對應
    ```
    1: 收到訊息
    2: workflow 執行中
    3: workflow 執行結束
    ```
  - 串流結束自動推播前端
  
- **TextDecorator.py**
  - 新增 `event_type` 判斷


## ✅ 如何測試 / How to Test
1. 確保 `itri-net` 已存在，不存在則執行
`docker network create itri-net`

2. 新增腳本 `run_all.sh`
    ```shell
    #!/bin/bash
    
    # 宣告 network
    NETWORK=itri-net
    IMAGE=itri-intent-backend
    
    function remove_container_if_exists() {
      local container_name="$1"
      if [ "$(docker ps -aq -f name=${container_name})" ]; then
        echo "Stopping and removing existing container: ${container_name}"
        docker stop "${container_name}" 2>/dev/null
        docker rm "${container_name}" 2>/dev/null
      fi
    }
    
    function remove_image_if_exists () {
      local image="$1"
      if docker images -q "${image}" | grep -q .; then
        echo "Removing old image ${image}"
        docker rmi -f "${image}" >/dev/null
      fi
    }
    
    remove_container_if_exists "itri-intent-backend"
    remove_container_if_exists "itri-intent-worker"
    remove_container_if_exists "intent-postgres-db"
    remove_container_if_exists "intent-redis-db"
    remove_container_if_exists "intent-pgadmin"
    remove_image_if_exists "${IMAGE}"
    
    
    source .env
    
    # 啟動 Postgres 容器
    docker run --network $NETWORK --name intent-postgres-db \
        -e POSTGRES_PASSWORD=$HTTP_POSTGRES_DATABASE_PASSWORD \
        -e POSTGRES_USER=$HTTP_POSTGRES_DATABASE_HOST_USER \
        -p $HTTP_POSTGRES_DATABASE_HOST_PORT:$HTTP_POSTGRES_DATABASE_HOST_PORT \
        -v ~/postgres_data:/var/lib/postgresql/data \
        -d postgres:latest
    
    sleep 5
    
    # 建立資料庫
    docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -c "CREATE DATABASE intent;"
    
    # 檢查資料庫列表
    # docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -l
    
    # 啟動 pgAdmin 容器
    docker run --network $NETWORK --name intent-pgadmin \
        -e PGADMIN_DEFAULT_EMAIL=$HTTP_PGADMIN_EMAIL \
        -e PGADMIN_DEFAULT_PASSWORD=$HTTP_PGADMIN_PASSWORD \
        -p $HTTP_PGADMIN_HOST_PORT:80 \
        -d dpage/pgadmin4
      
    #啟動 Redis 容器 
    docker run --network $NETWORK --name intent-redis-db \
      -e REDIS_USER=$HTTP_REDIS_DATABASE_HOST_USER \
      -e REDIS_PASSWORD=$HTTP_REDIS_DATABASE_PASSWORD \
      -p $HTTP_REDIS_DATABASE_HOST_PORT:$HTTP_REDIS_DATABASE_HOST_PORT \
      -d redis \
      sh -c 'echo "databases 16" > /tmp/redis.conf && \
             echo "user $REDIS_USER on >$REDIS_PASSWORD ~* +@all" >> /tmp/redis.conf && \
             redis-server /tmp/redis.conf'
             
    #包專案image
    docker build --no-cache -t itri-intent-backend ./
    
    # 啟動 意圖後端系統 容器
    docker run -d --network $NETWORK \
        --name itri-intent-backend \
        -p $HTTP_WORKFLOW_MGT_PORT:$HTTP_WORKFLOW_MGT_PORT \
        itri-intent-backend \
        sh -c "
          python manage.py migrate --noinput &&
          daphne -b 0.0.0.0 -p $HTTP_WORKFLOW_MGT_PORT main.asgi:application
        "
    
    # 啟動 意圖後端系統 Channels Worker 監聽 ChannelNameRouter
    docker run -d --network $NETWORK \
      --name itri-intent-worker \
      --env-file .env \
      itri-intent-backend \
      bash -c "source .env && python manage.py runworker consumer"
    ```

4. 跑佈署腳本
    ```shell
	chmod 777 run.sh
    ./run_all.sh
	```

5. 如果遇到 `/media` 權限問題，需手動設定權限


## 📜 測試項目 / Test Case

### 從前端操作須符合

1. 註冊
2. 登入
3. 獲取對話清單
5. 創建對話，並會自動生成標題
	- 輸入文本`查詢整體UE狀態`需顯示表格
	- 輸入文本`查詢SINR Map`需顯示圖片
	- 輸入文本`預測干擾抑制演算法`需顯示表格
	- 輸入文本`執行干擾抑制演算法`需顯示表格
	- 輸入文本`停用干擾抑制演算法`需顯示表格
6. 修改對話名稱
7. 刪除對話


### 從後端操作須符合

1. 正常解析不同來源，包括`system`, `Websocket`, `dify engine`
2. 狀態碼解析正常，不會出現定義之外狀況
3. 錯誤訊息能正常顯示
4. 正常記錄所有執行動作
5. 創建對話，redis 有相關紀錄，workflow_status 紀錄為 `1`
6. dify 處理時，workflow_status 紀錄為 `2`
7. dify 處理結束回傳前端後，workflow_status 紀錄為 `3`
8. 刪除對話，redis 不會有該 topic 存在


## 📷 螢幕截圖 / Demo
<img width="1913" height="930" alt="image" src="https://github.com/user-attachments/assets/e1a9cd7d-6f29-4339-a848-1b9c8122606c" />
