### PR TITLE
Feature/yihua/refactor input output format

### DIFF
--- a/main/apps/conversation_mgt/actors/ConversationManager.py
+++ b/main/apps/conversation_mgt/actors/ConversationManager.py
@@ -29,12 +29,15 @@ class ConversationManager:
         5) 在 Broker 註冊 topic
         """
         try:
-            # 1) 解析 JSON
             payload = json.loads(request.body)
-            if "user_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["user_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "Missing field: user_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
             user_uid = payload["user_uid"]
@@ -54,11 +57,11 @@ class ConversationManager:
                 meta_data = resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Fail to call metadata_mgt API: {str(e)}"
                 }, status=502)
 
-            if not meta_data.get("status", False):
+            if not meta_data.get("status_code", 400):
                 return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
 
             conversation_uid = meta_data["data"]["conversation_uid"]
@@ -78,12 +81,12 @@ class ConversationManager:
                 workflow_data = workflow_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Fail to call workflow metadata API: {str(e)}"
                 }, status=502)
 
             # 確認回傳結果是否成功
-            if not workflow_data.get("status", False):
+            if not workflow_data.get("status_code", 400):
                 return JsonResponse(workflow_data, status=workflow_data.get("status_code", 400))
 
             # 這裡如果需要 workflow_uid
@@ -94,7 +97,7 @@ class ConversationManager:
                 create_empty_csv(csv_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to create CSV file: {str(e)}"
                 }, status=500)
 
@@ -114,13 +117,13 @@ class ConversationManager:
                     return JsonResponse(topic_data, status=topic_data.get("status_code", 400))
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to register topic (topic_mgt) : {str(e)}"
                 }, status=500)
 
             # 全部成功
             return JsonResponse({
-                "status": True,
+                "status_code": 201,
                 "message": "Conversation created locally (CSV) and workflow metadata created",
                 "data": {
                     "conversation_uid": conversation_uid
@@ -129,9 +132,9 @@ class ConversationManager:
             }, status=201)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -150,12 +153,15 @@ class ConversationManager:
         3) 回傳結果
         """
         try:
-            # 1) 解析 JSON，檢查欄位
             payload = json.loads(request.body)
-            if "user_uid" not in payload:
+
+            # 1) 必填欄位檢查
+            required_fields = ["user_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "Missing field: user_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
             user_uid = payload["user_uid"]
@@ -174,25 +180,25 @@ class ConversationManager:
                 meta_data = resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt API: {str(e)}"
                 }, status=502)
 
-            if not meta_data.get("status", False):
+            if not meta_data.get("status_code", 400):
                 # 如果 metadata API 回傳 status = False，直接將其回傳
                 return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
 
             # 3) 回傳取得的對話清單
             return JsonResponse({
-                "status": True,
+                "status_code": 200,
                 "message": "Get conversation list success",
                 "data": meta_data.get("data", [])
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -212,12 +218,16 @@ class ConversationManager:
         try:
             # 1) 解析 JSON, 檢查必填欄位
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
-                return JsonResponse({
-                    "status": False,
-                    "message": "Missing field: conversation_uid"
-                }, status=400)
 
+            # 1) 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
+                return JsonResponse({
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
+                }, status=400)
+            
             conversation_uid = payload["conversation_uid"]
 
             # 2) 呼叫 metadata_mgt: get_conversation_metadata
@@ -232,11 +242,11 @@ class ConversationManager:
                 get_meta_data = resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt API (get_conversation_metadata): {str(e)}"
                 }, status=502)
 
-            if not get_meta_data.get("status", False):
+            if not get_meta_data.get("status_code", 400):
                 return JsonResponse(get_meta_data, status=get_meta_data.get("status_code", 400))
 
             # 取得 CSV 路徑與 user_uid
@@ -244,7 +254,7 @@ class ConversationManager:
             user_uid = get_meta_data["data"].get("user_uid")
             if not conversation_path or not user_uid:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "conversation_path or user_uid not found in metadata"
                 }, status=400)
 
@@ -253,7 +263,7 @@ class ConversationManager:
                 text_uids = read_text_uids_from_csv(conversation_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to read CSV file: {str(e)}"
                 }, status=500)
 
@@ -270,11 +280,11 @@ class ConversationManager:
                     del_text_data = resp_del_text.json()
                 except Exception as e:
                     return JsonResponse({
-                        "status": False,
+                        "status_code": 502,
                         "message": f"Fail to call delete_text for text_uid={text_uid}: {str(e)}"
                     }, status=502)
 
-                if not del_text_data.get("status", False):
+                if not del_text_data.get("status_code", 400):
                     # 即使某個 text 刪除失敗，可選擇直接中斷或繼續嘗試刪除其他 text
                     return JsonResponse(del_text_data, status=del_text_data.get("status_code", 400))
             
@@ -289,11 +299,11 @@ class ConversationManager:
                 del_meta_data = resp_del.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt API (delete_conversation_metadata): {str(e)}"
                 }, status=502)
 
-            if not del_meta_data.get("status", False):
+            if not del_meta_data.get("status_code", 400):
                 return JsonResponse(del_meta_data, status=del_meta_data.get("status_code", 400))
 
             # 6) 刪除 texts/{conversation_uid} 資料夾 (若裡面已空則快; 若有殘留檔案也能清掉)
@@ -302,7 +312,7 @@ class ConversationManager:
                 delete_folder(text_dir)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to remove folder texts/{conversation_uid}: {str(e)}"
                 }, status=500)
 
@@ -311,7 +321,7 @@ class ConversationManager:
                 delete_file(conversation_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to remove CSV file: {str(e)}"
                 }, status=500)
 
@@ -326,20 +336,20 @@ class ConversationManager:
                 del_meta_data = resp_del.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
-                    "message": f"Fail to call metadata_mgt API (delete_conversation_metadata): {str(e)}"
+                    "status_code": 502,
+                    "message": f"Fail to call topic_mgt API (delete_topic): {str(e)}"
                 }, status=502)
 
-            if not del_meta_data.get("status", False):
+            if not del_meta_data.get("status_code", 400):
                 return JsonResponse(del_meta_data, status=del_meta_data.get("status_code", 400))
 
             # 全部成功
             return JsonResponse({
-                "status": True,
+                "status_code": 200,
                 "message": "Conversation deleted"
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)

--- a/main/apps/conversation_mgt/actors/ImageManager.py
+++ b/main/apps/conversation_mgt/actors/ImageManager.py
@@ -32,7 +32,7 @@ class ImageManager:
             missing = [f for f in required_fields if f not in payload]
             if missing:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": f"Missing required fields: {', '.join(missing)}"
                 }, status=400)
             
@@ -50,7 +50,7 @@ class ImageManager:
                 meta_data = meta_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt: {str(e)}"
                 }, status=502)
 
@@ -75,12 +75,12 @@ class ImageManager:
                 
             except requests.exceptions.RequestException as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to download image from URL {content}: {str(e)}"
                 }, status=500)
             except Exception as e: # 捕獲其他可能的文件寫入錯誤
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to save image file locally: {str(e)}"
                 }, status=500)
 
@@ -91,9 +91,9 @@ class ImageManager:
             }, status=201)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -108,7 +108,7 @@ class ImageManager:
 
             if not conversation_uid:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "Missing required field: 'conversation_uid'"
                 }, status=400)
 
@@ -123,11 +123,11 @@ class ImageManager:
                 meta_data = meta_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt: {str(e)}"
                 }, status=502)
 
-            if not meta_data.get("status", False):
+            if not meta_data.get("status_code", 400):
                 return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
 
             image_list = []
@@ -150,9 +150,9 @@ class ImageManager:
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -170,7 +170,7 @@ class ImageManager:
 
             if not image_uid:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "Missing required field: 'image_uid'"
                 }, status=400)
 
@@ -185,7 +185,7 @@ class ImageManager:
                 meta_data = meta_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to get image metadata: {str(e)}"
                 }, status=502)
 
@@ -196,7 +196,7 @@ class ImageManager:
 
             if not image_path or not os.path.exists(image_path):
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 404,
                     "message": f"[{image_path}] Image file does not exist"
                 }, status=404)
 
@@ -205,7 +205,7 @@ class ImageManager:
                 delete_file(image_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to delete image file: {str(e)}"
                 }, status=500)
 
@@ -220,11 +220,11 @@ class ImageManager:
                 del_data = del_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to delete image metadata: {str(e)}"
                 }, status=502)
 
-            if not del_data.get("status", False):
+            if not del_data.get("status_code", 400):
                 return JsonResponse(del_data, status=del_data.get("status_code", 400))
 
             return JsonResponse({
@@ -233,9 +233,9 @@ class ImageManager:
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt 
     @require_http_methods(["POST"])
@@ -249,7 +249,7 @@ class ImageManager:
             missing = [f for f in required_fields if f not in payload]
             if missing:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": f"Missing required fields: {', '.join(missing)}"
                 }, status=400)
             

--- a/main/apps/conversation_mgt/actors/TextManager.py
+++ b/main/apps/conversation_mgt/actors/TextManager.py
@@ -45,7 +45,7 @@ class TextManager:
             missing = [f for f in required_fields if f not in payload]
             if missing:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": f"Missing required fields: {', '.join(missing)}"
                 }, status=400)
 
@@ -55,13 +55,14 @@ class TextManager:
 
             if not isinstance(text_array, list):
                 return JsonResponse({
-                    "status": False, "message": "Field 'text_content' must be a list"
+                    "status_code": 400,
+                    "message": "Field 'text_content' must be a list"
                 }, status=400)
 
             for item in text_array:
                 if not isinstance(item, dict) or "type" not in item or "content" not in item:
                     return JsonResponse({
-                        "status": False,
+                        "status_code": 400,
                         "message": "Each element in 'text_content' must have 'type' and 'content'"
                     }, status=400)
 
@@ -76,11 +77,11 @@ class TextManager:
                 conv_meta_data = conv_meta_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt (get_conversation_metadata): {str(e)}"
                 }, status=502)
 
-            if not conv_meta_data.get("status", False):
+            if not conv_meta_data.get("status_code", 400):
                 return JsonResponse(conv_meta_data, status=conv_meta_data.get("status_code", 400))
             # **[優化]** 將標題生成邏輯移出迴圈，僅在需要時執行一次
 
@@ -139,7 +140,7 @@ class TextManager:
                         image_uid = result.get("data", {}).get("image_uid")
                         if not image_uid:
                             return JsonResponse({
-                                "status": False,
+                                "status_code": 500,
                                 "message": f"image_uid 不存在於回傳值中: {result}"
                             }, status=500)
 
@@ -147,7 +148,7 @@ class TextManager:
 
                     except Exception as e:
                         return JsonResponse({
-                            "status": False,
+                            "status_code": 500,
                             "message": f"Failed to create image metadata: {str(e)}"
                         }, status=500)
 
@@ -162,11 +163,11 @@ class TextManager:
                 text_meta_data = text_meta_resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt (create_text_metadata): {str(e)}"
                 }, status=502)
 
-            if not text_meta_data.get("status", False):
+            if not text_meta_data.get("status_code", 400):
                 return JsonResponse(text_meta_data, status=text_meta_data.get("status_code", 400))
 
             data_part = text_meta_data.get("data", {})
@@ -176,7 +177,7 @@ class TextManager:
 
             if not all([text_uid, user_uid, text_path]):
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": "Missing critical data in metadata response (need text_uid, user_uid, text_path)"
                 }, status=500) # 使用 500，因為這是後端服務間的契約問題
 
@@ -189,7 +190,7 @@ class TextManager:
             except Exception as e:
                 # 考慮補償交易：若此步失敗，是否應刪除剛建立的 text metadata？
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to append text_uid to CSV: {str(e)}"
                 }, status=500)
 
@@ -201,13 +202,13 @@ class TextManager:
                 })
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to create/write text JSON: {str(e)}"
                 }, status=500)
 
             # (5) 回傳結果
             return JsonResponse({
-                "status": True,
+                "status_code": 201,
                 "message": "Text created successfully",
                 "data": {
                     "text_uid": text_uid
@@ -215,10 +216,10 @@ class TextManager:
             }, status=201)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
             # 捕捉所有其他未預期的錯誤
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -239,7 +240,7 @@ class TextManager:
             payload = json.loads(request.body)
             if "conversation_uid" not in payload:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "Missing required field: conversation_uid"
                 }, status=400)
 
@@ -257,17 +258,17 @@ class TextManager:
                 get_meta_data = resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt (get_conversation_metadata): {str(e)}"
                 }, status=502)
 
-            if not get_meta_data.get("status", False):
+            if not get_meta_data.get("status_code", 400):
                 return JsonResponse(get_meta_data, status=get_meta_data.get("status_code", 400))
 
             conversation_path = get_meta_data["data"].get("conversation_path")
             if not conversation_path:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "conversation_path not found in metadata"
                 }, status=400)
 
@@ -276,14 +277,14 @@ class TextManager:
                 text_uids = read_text_uids_from_csv(conversation_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to read CSV: {str(e)}"
                 }, status=500)
 
             # 如果 conversation_csv 內沒有任何 text_uid，可直接回傳
             if not text_uids:
                 return JsonResponse({
-                    "status": True,
+                    "status_code": 200,
                     "message": "No text records found in this conversation",
                     "data": []
                 }, status=200)
@@ -293,14 +294,14 @@ class TextManager:
                 data_list = read_text_jsons(conversation_uid, text_uids)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to read text JSONs: {str(e)}"
                 }, status=500)
 
             # 防範 data_list 可能為空或無內容
             if not data_list:
                 return JsonResponse({
-                    "status": True,
+                    "status_code": 200,
                     "message": "No text JSON files found for this conversation",
                     "data": []
                 }, status=200)
@@ -333,7 +334,7 @@ class TextManager:
             #                 block["content"] = f"[Error calling metadata_mgt for image_uid={image_uid}: {str(e)}]"
             #                 continue
 
-            #             if not img_data.get("status", False):
+            #             if not img_data.get("status_code", 400):
             #                 # 留下錯誤訊息，但可繼續其他 block
             #                 block["content"] = f"[Error: {img_data.get('message', 'Unknown error')}]"
             #                 continue
@@ -354,15 +355,15 @@ class TextManager:
 
             # (5) 回傳最終整理後的 data_list
             return JsonResponse({
-                "status": True,
+                "status_code": 200,
                 "message": "Get text list success",
                 "data": data_list
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -381,7 +382,7 @@ class TextManager:
             payload = json.loads(request.body)
             if "text_uid" not in payload:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "Missing required field: text_uid"
                 }, status=400)
 
@@ -399,17 +400,17 @@ class TextManager:
                 get_meta_data = resp.json()
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 502,
                     "message": f"Fail to call metadata_mgt (get_text_metadata): {str(e)}"
                 }, status=502)
 
-            if not get_meta_data.get("status", False):
+            if not get_meta_data.get("status_code", 400):
                 return JsonResponse(get_meta_data, status=get_meta_data.get("status_code", 400))
 
             text_path = get_meta_data["data"].get("text_path")
             if not text_path:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 400,
                     "message": "text_path not found in metadata"
                 }, status=400)
 
@@ -421,7 +422,7 @@ class TextManager:
                         text_data = json.load(f)
                 except Exception as e:
                     return JsonResponse({
-                        "status": False,
+                        "status_code": 500,
                         "message": f"Failed to read JSON file: {str(e)}"
                     }, status=500)
 
@@ -445,7 +446,7 @@ class TextManager:
                         return JsonResponse(del_data, status=del_data.get("status_code", 400))
                 except Exception as e:
                     return JsonResponse({
-                        "status": False,
+                        "status_code": 502,
                         "message": f"Fail to delete image metadata: {str(e)}"
                     }, status=502)
 
@@ -454,18 +455,18 @@ class TextManager:
                 delete_file(text_path)
             except Exception as e:
                 return JsonResponse({
-                    "status": False,
+                    "status_code": 500,
                     "message": f"Failed to remove text JSON file: {str(e)}"
                 }, status=500)
             
             # 5) 回傳成功
             return JsonResponse({
-                "status": True,
+                "status_code": 200,
                 "message": "Text deleted"
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)
         

--- a/main/apps/metadata_mgt/actors/ConversationManager.py
+++ b/main/apps/metadata_mgt/actors/ConversationManager.py
@@ -18,22 +18,20 @@ class ConversationManager():
     def create_conversation_metadata(request):
         """
         Input (POST JSON):
-            f_user_uid (必填)
-            conversation_name (選填)
+            user_uid (必填)
+            conversation_name (必填)
 
-        Output (JsonResponse):
-            - conversation_path 不需前端傳入，會在後端自動組合
+        Output (JsonResponse)
         """
         try:
             payload = json.loads(request.body)
 
             # 必填欄位檢查
-            required_fields = ["user_uid","conversation_name"]
+            required_fields = ["user_uid", "conversation_name"]
             missing_fields = [f for f in required_fields if f not in payload]
             if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
                     "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
@@ -48,13 +46,11 @@ class ConversationManager():
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
@@ -70,27 +66,29 @@ class ConversationManager():
         """
         try:
             payload = json.loads(request.body)
-            if "user_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["user_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 user_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
             # 呼叫 Controller 查詢
             response = ConversationController.get_user_conversation_metadata_list(payload["user_uid"])
 
             return JsonResponse(response, status=response["status_code"])
+        
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
@@ -106,26 +104,29 @@ class ConversationManager():
         """
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 conversation_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 查詢
             response = ConversationController.get_conversation(payload["conversation_uid"])
 
             return JsonResponse(response, status=response["status_code"])
+        
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
@@ -135,47 +136,39 @@ class ConversationManager():
     def update_conversation_name(request):
         """
         Input (POST JSON):
-            {
-                "conversation_uid": <string>,
-                "conversation_name": <string>
-            }
+            conversation_uid (必填)
+            conversation_name (必填)
 
-        Output (JsonResponse):
-            {
-                "status": <bool>,
-                "message": <string>
-            }
+        Output (JsonResponse)
         """
         try:
             payload = json.loads(request.body)
 
-            # 檢查必填欄位
-            if "conversation_uid" not in payload or "conversation_name" not in payload:
+            # 必填欄位檢查
+            required_fields = ["conversation_uid", "conversation_name"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少必填欄位: conversation_uid, conversation_name"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            # 呼叫 Controller
+            # 呼叫 Controller 更新
             response = ConversationController.update_conversation_name(
                 conversation_uid=payload["conversation_uid"],
                 conversation_name=payload["conversation_name"]
             )
 
-            # 從 Controller 回傳的資料只取 status、message 即可
-            return JsonResponse({
-                "status": response["status"],
-                "message": response["message"]
-            }, status=response["status_code"])
+            return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": False,
+                "status_code": 400,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
-                "status": False,
+                "status_code": 500,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
@@ -191,26 +184,29 @@ class ConversationManager():
         """
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 conversation_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 刪除
             response = ConversationController.delete_conversation(payload["conversation_uid"])
 
             return JsonResponse(response, status=response["status_code"])
+        
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
         
@@ -220,44 +216,34 @@ class ConversationManager():
     def verify_conversation_exist(request):
         """
         Input (POST JSON):
-            {
-                "conversation_uid": <string>
-            }
+            conversation_uid (必填)
 
-        Output (JsonResponse):
-            {
-                "status_code": <int>,
-                "message": <string>
-            }
+        Output (JsonResponse)
         """
         try:
             payload = json.loads(request.body)
 
-            # 檢查必填欄位
-            if "conversation_uid" not in payload:
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少必填欄位: conversation_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            # 呼叫 Controller
-            response = ConversationController.get_conversation(
-                conversation_uid=payload["conversation_uid"]
-            )
+            # 呼叫 Controller 查詢
+            response = ConversationController.get_conversation(conversation_uid=payload["conversation_uid"])
 
-            # 從 Controller 回傳的資料只取 status、message 即可
-            return JsonResponse({
-                "status": response["status"],
-                "message": response["message"]
-            }, status=response["status_code"])
+            return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": False,
+                "status_code": 400,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
-                "status": False,
+                "status_code": 500,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)

--- a/main/apps/metadata_mgt/actors/ImageManager.py
+++ b/main/apps/metadata_mgt/actors/ImageManager.py
@@ -13,15 +13,19 @@ class ImageManager:
     def create_image_metadata(request):
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "message": "缺少欄位: conversation_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
+            
+            # 呼叫 Controller 建立
+            response = ImageController.create_image(payload["conversation_uid"])
 
-            response = ImageController.create_image(
-                conversation_uid=payload["conversation_uid"]
-            )
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
@@ -32,7 +36,7 @@ class ImageManager:
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "message": f"系統錯誤: {str(e)}"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -41,13 +45,19 @@ class ImageManager:
     def get_image_metadata(request):
         try:
             payload = json.loads(request.body)
-            if "image_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["image_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "message": "缺少欄位: image_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 查詢
             response = ImageController.get_image_metadata_by_uid(payload["image_uid"])
+
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
@@ -58,7 +68,7 @@ class ImageManager:
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "message": f"系統錯誤: {str(e)}"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -67,13 +77,19 @@ class ImageManager:
     def get_image_metadata_list(request):
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "message": "缺少欄位: conversation_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 查詢
             response = ImageController.get_image_list_by_conversation(payload["conversation_uid"])
+            
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
@@ -84,7 +100,7 @@ class ImageManager:
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "message": f"系統錯誤: {str(e)}"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -93,13 +109,19 @@ class ImageManager:
     def delete_image_metadata(request):
         try:
             payload = json.loads(request.body)
-            if "image_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["image_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "message": "缺少欄位: image_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 查詢
             response = ImageController.delete_image_by_uid(payload["image_uid"])
+            
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
@@ -110,5 +132,5 @@ class ImageManager:
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "message": f"系統錯誤: {str(e)}"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)

--- a/main/apps/metadata_mgt/actors/TextManager.py
+++ b/main/apps/metadata_mgt/actors/TextManager.py
@@ -11,34 +11,38 @@ class TextManager:
     @require_http_methods(["POST"])
     @log_trigger()
     def create_text_metadata(request):
+        """
+        Input (POST JSON):
+            conversation_uid (必填)
+
+        Output (JsonResponse)
+        """
         try:
             payload = json.loads(request.body)
 
+            # 必填欄位檢查
             required_fields = ["conversation_uid"]
-            missing = [f for f in required_fields if f not in payload]
-            if missing:
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": f"Missing field(s): {', '.join(missing)}"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            response = TextController.create_text(
-                conversation_uid=payload["conversation_uid"],
-            )
+            # 呼叫 Controller 建立
+            response = TextController.create_text(payload["conversation_uid"])
+
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
-                "message": "Invalid JSON"
+                "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
-                "message": str(e)
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
         
     @csrf_exempt
@@ -47,104 +51,71 @@ class TextManager:
     def get_text_metadata(request):
         """
         Input (POST JSON):
-        {
-            "text_uid": <string>
-        }
+            text_uid (必填)
 
-        Output (JsonResponse):
-        {
-            "status": <bool>,
-            "message": <string>,
-            "data": {
-                "text_uid": <string>,
-                "text_path": <string>,
-                "created_at": <string>
-            }
-        }
+        Output (JsonResponse)
         """
         try:
             payload = json.loads(request.body)
 
-            # (1) 檢查必填欄位
-            if "text_uid" not in payload:
+            # 必填欄位檢查
+            required_fields = ["text_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少必填欄位: text_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            # (2) 透過 text_uid 找對應的 text metadata
+            # 呼叫 Controller 查詢
             response = TextController.get_text_metadata_by_uid(payload["text_uid"])
 
-            # 整理回傳給前端的 JSON
-            return JsonResponse({
-                "status": response["status"],
-                "message": response["message"],
-                "data": response.get("data", {})
-            }, status=response["status_code"])
+            return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": False,
+                "status_code": 400,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
-                "status": False,
+                "status_code": 500,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
-        
 
     @log_trigger()
     def get_text_metadata_list(request):
         """
         Input (POST JSON):
-        {
-            "conversation_uid": <string>
-        }
+            conversation_uid (必填)
 
-        Output (JsonResponse):
-        {
-            "status": <bool>,
-            "message": <string>,
-            "data": [
-                {
-                    "text_uid": <string>,
-                    "text_path": <string>,
-                    "created_at": <string>,
-                },
-                ...
-            ]
-        }
+        Output (JsonResponse)
         """
         try:
-            # 1. 解析 JSON payload
             payload = json.loads(request.body)
 
-            # 2. 檢查必填欄位
-            if "conversation_uid" not in payload:
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少必填欄位: conversation_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            # 3. 呼叫 Controller 查詢並回傳結果
+            # 呼叫 Controller 查詢
             response = TextController.get_text_list_by_conversation(payload["conversation_uid"])
 
-            # 統一回傳格式
-            return JsonResponse({
-                "status": response["status"],
-                "message": response["message"],
-                "data": response.get("data", [])
-            }, status=response["status_code"])
+            return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": False,
+                "status_code": 400,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
-                "status": False,
+                "status_code": 500,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
         
@@ -152,43 +123,34 @@ class TextManager:
     def delete_text_metadata(request):
         """
         Input (POST JSON):
-        {
-            "text_uid": <uid>
-        }
+            text_uid (必填)
 
-        Output (JsonResponse):
-        {
-            "status": <bool>,
-            "message": <string>
-        }
+        Output (JsonResponse)
         """
         try:
-            # 1) 解析 JSON
             payload = json.loads(request.body)
 
-            # 2) 檢查必填欄位
-            if "text_uid" not in payload:
+            # 必填欄位檢查
+            required_fields = ["text_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少必填欄位: text_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
             
-            # 3) 呼叫 Controller 刪除資料
-            response = TextController.delete_text_by_uid(text_uid=text_uid)
+            # 呼叫 Controller 刪除
+            response = TextController.delete_text_by_uid(payload["text_uid"])
 
-            # 4) 統一回傳格式
-            return JsonResponse({
-                "status": response["status"],
-                "message": response["message"]
-            }, status=response["status_code"])
+            return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": False,
+                "status_code": 400,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
-                "status": False,
+                "status_code": 500,
                 "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)

--- a/main/apps/metadata_mgt/actors/UserManager.py
+++ b/main/apps/metadata_mgt/actors/UserManager.py
@@ -25,7 +25,6 @@ class UserManager:
                 "message": "Hello World"
             }, status=200)
         except Exception as e:
-            # log_writer(log_writer(log_level="ERROR", message=str(e)))
             return JsonResponse({
                 "status_code": 500,
                 "status": False,
@@ -42,38 +41,33 @@ class UserManager:
         try:
             payload = json.loads(request.body)
 
-            required_fields = ["username", "password", "email"]
+            # 必填欄位檢查
+            required_fields = ["user_uname", "user_password", "user_uemail"]
             missing_fields = [f for f in required_fields if f not in payload]
             if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
                     "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 建立
             response = UserController.create_user(
-                user_name=payload['username'],
-                user_password=payload['password'],
-                user_email=payload['email']
+                user_uname=payload['user_uname'],
+                user_password=payload['user_password'],
+                user_uemail=payload['user_uemail']
             )
-
-            # log_writer(log_writer(log_level="INFO" if response["status"] else "ERROR", message=response["message"]))
 
             return JsonResponse(response, status=response["status_code"])
 
-        except json.JSONDecodeError as e:
-            # log_writer(log_writer(log_level="ERROR", message=f"JSONDecodeError: {str(e))}")
+        except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
-            # log_writer(log_writer(log_level="ERROR", message=str(e)))
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
-                "message": f"{str(e)}"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -84,36 +78,32 @@ class UserManager:
             payload = json.loads(request.body)
 
             # 檢查必要欄位
-            required_fields = ['username', 'password']
-            for field in required_fields:
-                if field not in payload:
-                    return JsonResponse({
-                        "status": "error",
-                        "message": f"Missing required field: {field}"
-                    }, status=400)
+            required_fields = ['user_uname', 'user_password']
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
+                return JsonResponse({
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
+                }, status=400)
 
             # 呼叫 Controller 登入邏輯
             response = UserController.login_user(
-                username=payload['username'],
-                userpassword=payload['password']
+                user_uname=payload['user_uname'],
+                user_password=payload['user_password']
             )
 
-            # 使用 Controller 回傳的 status_code 作為 HTTP 回應碼
             return JsonResponse(response, status=response["status_code"])
 
         except json.JSONDecodeError:
             return JsonResponse({
-                "status": "error",
-                "message": "Invalid JSON format"
+                "status_code": 400,
+                "message": "無效的 JSON 格式"
             }, status=400)
-
         except Exception as e:
             return JsonResponse({
-                "status": "error",
-                "message": str(e)
+                "status_code": 500,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
-
-           
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -124,33 +114,30 @@ class UserManager:
         """
         try:
             payload = json.loads(request.body)
-            user_name = payload.get("user_name")
-            if not user_name:
+
+            # 必填欄位檢查
+            required_fields = ["user_uname"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 user_name"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            response = UserController.get_user_by_name(user_name)
-
-            # log_writer(log_writer(log_level="INFO" if response["status"] else "ERROR", message=response["message"]))
+            # 呼叫 Controller 查詢
+            response = UserController.get_user_by_name(payload["user_uname"])
 
             return JsonResponse(response, status=response["status_code"])
 
-        except json.JSONDecodeError as e:
-            # log_writer(log_writer(log_level="ERROR", message=f"JSONDecodeError: {str(e))}")
+        except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
-            # log_writer(log_writer(log_level="ERROR", message=str(e)))
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
-                "message": "系統發生錯誤，請稍後再試"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -162,36 +149,32 @@ class UserManager:
         """
         try:
             payload = json.loads(request.body)
-            user_uid = payload.get("user_uid")
-            if not user_uid:
+
+            # 必填欄位檢查
+            required_fields = ["user_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 user_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
-            update_fields = {
-                k: v for k, v in payload.items() if k != "user_uid"
-            }
-            response = UserController.update_user(user_uid, **update_fields)
-
-            # log_writer(log_writer(log_level="INFO" if response["status"] else "ERROR", message=response["message"]))
+            update_fields = {k: v for k, v in payload.items() if k != "user_uid"}
+            
+            # 呼叫 Controller 更新
+            response = UserController.update_user(payload.get("user_uid"), **update_fields)
 
             return JsonResponse(response, status=response["status_code"])
 
-        except json.JSONDecodeError as e:
-            # log_writer(log_writer(log_level="ERROR", message=f"JSONDecodeError: {str(e))}")
+        except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
-            # log_writer(log_writer(log_level="ERROR", message=str(e)))
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
-                "message": "系統發生錯誤，請稍後再試"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)
 
     @csrf_exempt
@@ -207,13 +190,17 @@ class UserManager:
         """
         try:
             payload = json.loads(request.body)
-            user_uid = payload.get("user_uid")
-            if not user_uid:
+
+            # 必填欄位檢查
+            required_fields = ["user_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
-                    "message": "缺少 user_uid"
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
+            
+            user_uid = payload.get("user_uid")
 
             # (A) 先取得該 user 的所有 conversation
             try:
@@ -223,17 +210,16 @@ class UserManager:
                     actor="ConversationManager",
                     function="get_conversation_metadata_list",
                     payload=meta_payload
-                    )
+                )
                 conversation_data = resp.json()
             except Exception as e:
                 return JsonResponse({
                     "status_code": 500,
-                    "status": False,
-                    "message": f"Fail to fetch conversation list from metadata_mgt: {str(e)}"
+                    "message": f"獲取 get_conversation_metadata_list() 失敗: {str(e)}"
                 }, status=500)
 
-            if not conversation_data.get("status", False):
-                return JsonResponse(conversation_data, status=conversation_data.get("status_code", 400))
+            if not conversation_data.get("status_code", 400):
+                return JsonResponse(conversation_data, status=conversation_data.get("status_code"))
 
             # (B) 刪除 conversation 相關檔案
             #     conversation_data["data"] 預期是一個 list，每個元素包含 
@@ -268,19 +254,16 @@ class UserManager:
             # 全部成功
             return JsonResponse({
                 "status_code": 200,
-                "status": True,
-                "message": "User and related conversations have been deleted successfully"
+                "message": "使用者刪除成功"
             }, status=200)
 
         except json.JSONDecodeError:
             return JsonResponse({
                 "status_code": 400,
-                "status": False,
                 "message": "無效的 JSON 格式"
             }, status=400)
         except Exception as e:
             return JsonResponse({
                 "status_code": 500,
-                "status": False,
-                "message": "系統發生錯誤，請稍後再試"
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
             }, status=500)

--- a/main/apps/metadata_mgt/actors/WorkflowManager.py
+++ b/main/apps/metadata_mgt/actors/WorkflowManager.py
@@ -33,13 +33,15 @@ class WorkflowManager:
         try:
             payload = json.loads(request.body)
 
-            # 1) 驗證必填欄位
-            if "conversation_uid" not in payload:
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "conversation_uid 為必填"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
-
+            
             # 2) 取出參數，若沒給則使用預設
             conversation_uid = payload["conversation_uid"]
             workflow_step = payload.get("workflow_step", "A")
@@ -54,10 +56,15 @@ class WorkflowManager:
             return JsonResponse(result, status=result["status_code"])
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({
+                "status_code": 400,
+                "message": "無效的 JSON 格式"
+            }, status=400)
         except Exception as e:
-            # 記錄錯誤訊息到 logger
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({
+                "status_code": 500,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
+            }, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -74,20 +81,31 @@ class WorkflowManager:
         """
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "conversation_uid 為必填"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
             # 呼叫 Controller 查詢
             result = WorkflowController.get_workflow_by_conversation(payload["conversation_uid"])
+            
             return JsonResponse(result, status=result["status_code"])
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({
+                "status_code": 400,
+                "message": "無效的 JSON 格式"
+            }, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({
+                "status_code": 500,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
+            }, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -109,22 +127,33 @@ class WorkflowManager:
         """
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "缺少conversation_uid"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
             conversation_uid = payload.pop("conversation_uid")
 
             # 其餘欄位都視為可更新參數，丟到 Controller
             result = WorkflowController.update_workflow(conversation_uid, **payload)
+
             return JsonResponse(result, status=result["status_code"])
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({
+                "status_code": 400,
+                "message": "無效的 JSON 格式"
+            }, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({
+                "status_code": 500,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
+            }, status=500)
 
     @csrf_exempt
     @require_http_methods(["POST"])
@@ -141,16 +170,28 @@ class WorkflowManager:
         """
         try:
             payload = json.loads(request.body)
-            if "conversation_uid" not in payload:
+
+            # 必填欄位檢查
+            required_fields = ["conversation_uid"]
+            missing_fields = [f for f in required_fields if f not in payload]
+            if missing_fields:
                 return JsonResponse({
-                    "status": False,
-                    "message": "conversation_uid 為必填"
+                    "status_code": 400,
+                    "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
+            # 呼叫 Controller 刪除
             result = WorkflowController.delete_workflow(payload["conversation_uid"])
+
             return JsonResponse(result, status=result["status_code"])
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({
+                "status_code": 400,
+                "message": "無效的 JSON 格式"
+            }, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({
+                "status_code": 500,
+                "message": f"系統發生錯誤，請稍後再試: {str(e)}"
+            }, status=500)

--- a/main/apps/metadata_mgt/models/UserModel.py
+++ b/main/apps/metadata_mgt/models/UserModel.py
@@ -5,10 +5,10 @@ import uuid
 class User(models.Model):
     user_id = models.AutoField(primary_key=True) 
     user_uid = models.UUIDField(default=uuid.uuid4, unique=True)
-    user_name = models.CharField(max_length=50,unique=True)
+    user_uname = models.CharField(max_length=50,unique=True)
     user_password = models.CharField(max_length=255)
     user_role = models.CharField(max_length=50, blank=True, null=True)
-    user_email = models.CharField(max_length=255, unique=True)
+    user_uemail = models.CharField(max_length=255, unique=True)
     created_time = models.DateTimeField(default=timezone.now)
     last_login_time = models.DateTimeField(null=True, blank=True)
 
@@ -16,4 +16,4 @@ class User(models.Model):
         db_table = 'user'
 
     def __str__(self):
-        return self.user_name
+        return self.user_uname

--- a/main/apps/metadata_mgt/services/ConversationController.py
+++ b/main/apps/metadata_mgt/services/ConversationController.py
@@ -14,13 +14,12 @@ class ConversationController:
           格式: {CONVERSATION_FOLDER_PATH}/{user_uid}/{conversation_uid}.json
 
         Input:
-            f_user_uid: 使用者的 user_uid (UUID)
+            user_uid: 使用者的 user_uid (UUID)
             conversation_name: (選填) 對話顯示名稱
 
         Output:
             dict: {
                "status_code": <int>,
-               "status": <bool>,
                "message": <str>,
                "data": {...} (若成功建立則回傳對應資料)
             }
@@ -32,7 +31,6 @@ class ConversationController:
             except ObjectDoesNotExist:
                 return {
                     "status_code": 404,
-                    "status": False,
                     "message": f"找不到 user_uid = {f_user_uid}"
                 }
 
@@ -51,8 +49,7 @@ class ConversationController:
 
             return {
                 "status_code": 201,
-                "status": True,
-                "message": "Conversation created successfully",
+                "message": "成功創建對話",
                 "data": {
                     "conversation_uid": str(conversation.conversation_uid),
                     "user_uid": str(conversation.f_user_uid.user_uid),
@@ -62,11 +59,9 @@ class ConversationController:
                     "updated_at": conversation.updated_at.isoformat()
                 }
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }
 
@@ -79,7 +74,6 @@ class ConversationController:
             conversation = Conversation.objects.get(conversation_uid=conversation_uid)
             return {
                 "status_code": 200,
-                "status": True,
                 "message": "成功取得對話",
                 "data": {
                     "conversation_uid": str(conversation.conversation_uid),
@@ -93,17 +87,14 @@ class ConversationController:
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": f"找不到 conversation_uid = {conversation_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }
 
-    
     @staticmethod
     def get_user_conversation_metadata_list(user_uid):
         """
@@ -114,7 +105,6 @@ class ConversationController:
             if not User.objects.filter(user_uid=user_uid).exists():
                 return {
                     "status_code": 404,
-                    "status": False,
                     "message": f"找不到 user_uid = {user_uid}"
                 }
 
@@ -135,15 +125,12 @@ class ConversationController:
 
             return {
                 "status_code": 200,
-                "status": True,
                 "message": "成功取得使用者所有對話",
                 "data": data_list
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }
 
@@ -159,19 +146,16 @@ class ConversationController:
 
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Update conversation name success"
+                "message": "成功更新對話名稱"
             }
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Can't find conversation_uid = {conversation_uid}"
+                "message": f"找不到 conversation_uid = {conversation_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }    
 
@@ -185,19 +169,16 @@ class ConversationController:
             conversation.delete()
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "刪除對話成功"
+                "message": "成功刪除對話"
             }
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": f"找不到 conversation_uid = {conversation_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }
         
@@ -210,20 +191,17 @@ class ConversationController:
             conversation = Conversation.objects.get(conversation_uid=conversation_uid)
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "取得 Dify conversation ID 成功",
+                "message": "成功取得 Dify conversation ID",
                 "data": conversation.dify_conversation_id
             }
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Can't find conversation_uid = {conversation_uid}"
+                "message": f"找不到 conversation_uid = {conversation_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }
 
@@ -239,18 +217,15 @@ class ConversationController:
 
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Update Dify conversation ID success"
+                "message": "成功更新 Dify conversation ID"
             }
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Can't find conversation_uid = {conversation_uid}"
+                "message": f"找不到 conversation_uid = {conversation_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
                 "message": f"系統發生錯誤: {str(e)}"
             }

--- a/main/apps/metadata_mgt/services/ImageController.py
+++ b/main/apps/metadata_mgt/services/ImageController.py
@@ -8,20 +8,20 @@ class ImageController:
     @staticmethod
     def create_image(conversation_uid):
         try:
-            # 驗證 Conversation 是否存在
+            # 1) 驗證 Conversation 是否存在
             try:
                 conversation = Conversation.objects.get(conversation_uid=conversation_uid)
             except ObjectDoesNotExist:
                 return {
                     "status_code": 404,
-                    "message": f"Conversation not found: {conversation_uid}"
+                    "message": f"找不到 conversation_uid = {conversation_uid}"
                 }
 
-            # 建立新 image_uid 與路徑
+            # 2) 建立新 image_uid 與路徑
             new_image_uid = uuid.uuid4()
             image_path = f"images/{conversation_uid}/{new_image_uid}.png"
 
-            # 建立 Image 紀錄
+            # 3) 建立 Image 紀錄
             image_obj = Image.objects.create(
                 image_uid=new_image_uid,
                 image_path=image_path,
@@ -38,11 +38,10 @@ class ImageController:
                     "created_at": image_obj.created_at.isoformat()
                 }
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -62,12 +61,12 @@ class ImageController:
         except Image.DoesNotExist:
             return {
                 "status_code": 404,
-                "message": f"Image not found: {image_uid}"
+                "message": f"找不到 image_uid = {image_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -76,7 +75,7 @@ class ImageController:
             if not Conversation.objects.filter(conversation_uid=conversation_uid).exists():
                 return {
                     "status_code": 404,
-                    "message": f"Conversation not found: {conversation_uid}"
+                    "message": f"找不到 conversation_uid = {conversation_uid}"
                 }
 
             images = Image.objects.filter(f_conversation_uid=conversation_uid).order_by('created_at')
@@ -94,11 +93,10 @@ class ImageController:
                 "message": "Image 查詢清單成功",
                 "data": data
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -113,10 +111,10 @@ class ImageController:
         except Image.DoesNotExist:
             return {
                 "status_code": 404,
-                "message": f"Image not found: {image_uid}"
+                "message": f"找不到 image_uid = {image_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }

--- a/main/apps/metadata_mgt/services/TextController.py
+++ b/main/apps/metadata_mgt/services/TextController.py
@@ -22,8 +22,7 @@ class TextController:
             except ObjectDoesNotExist:
                 return {
                     "status_code": 404,
-                    "status": False,
-                    "message": f"Conversation not found: {conversation_uid}"
+                    "message": f"找不到 conversation_uid = {conversation_uid}"
                 }
 
             # 2) 取得與該 Conversation 綁定的使用者
@@ -44,8 +43,7 @@ class TextController:
 
             return {
                 "status_code": 201,
-                "status": True,
-                "message": "Text created successfully",
+                "message": "Text 創建成功",
                 "data": {
                     "text_uid": str(text_obj.text_uid),
                     "user_uid": str(user.user_uid),
@@ -54,12 +52,10 @@ class TextController:
                     "created_at": text_obj.created_at.isoformat()
                 }
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -71,25 +67,22 @@ class TextController:
             text_obj = Text.objects.get(text_uid=text_uid)
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Get text success",
+                "message": "Text 查詢成功",
                 "data": {
                     "text_uid": str(text_obj.text_uid),
                     "text_path": text_obj.text_path,
                     "created_at": text_obj.created_at.isoformat(),
                 }
             }
-        except Text.DoesNotExist:
+        except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Text not found: {text_uid}"
+                "message": f"找不到 text_uid = {text_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -103,8 +96,7 @@ class TextController:
             if not Conversation.objects.filter(conversation_uid=conversation_uid).exists():
                 return {
                     "status_code": 404,
-                    "status": False,
-                    "message": f"Conversation not found: {conversation_uid}"
+                    "message": f"找不到 conversation_uid = {conversation_uid}"
                 }
             
             texts = Text.objects.filter(f_conversation_uid=conversation_uid).order_by('created_at')
@@ -119,16 +111,13 @@ class TextController:
             
             return {
                 "status_code": 200,
-                "status": True,
-                "message": f"Get texts success (count={len(data_list)})",
+                "message": f"成功取得對話下的 Text 清單",
                 "data": data_list
             }
-
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -150,8 +139,7 @@ class TextController:
 
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Text updated successfully",
+                "message": "Text 更新成功",
                 "data": {
                     "text_uid": str(text_obj.text_uid),
                     "text_path": text_obj.text_path,
@@ -160,19 +148,16 @@ class TextController:
                     "f_user_uid": str(text_obj.f_user_uid.user_uid)
                 }
             }
-
-        except Text.DoesNotExist:
+        except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Text not found: {text_uid}"
+                "message": f"找不到 text_uid = {text_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server error: {str(e)}"
-            }
+                "message": f"系統發生錯誤: {str(e)}"
+            }    
 
     @staticmethod
     def delete_text_by_uid(text_uid):
@@ -184,18 +169,15 @@ class TextController:
             text_obj.delete()
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Text deleted successfully"
+                "message": "Text 刪除成功"
             }
-        except Text.DoesNotExist:
+        except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": f"Text not found: {text_uid}"
+                "message": f"找不到 text_uid = {text_uid}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }

--- a/main/apps/metadata_mgt/services/TextController.py
+++ b/main/apps/metadata_mgt/services/TextController.py
@@ -74,7 +74,7 @@ class TextController:
                     "created_at": text_obj.created_at.isoformat(),
                 }
             }
-        except Conversation.DoesNotExist:
+        except Text.DoesNotExist:
             return {
                 "status_code": 404,
                 "message": f"找不到 text_uid = {text_uid}"
@@ -148,7 +148,7 @@ class TextController:
                     "f_user_uid": str(text_obj.f_user_uid.user_uid)
                 }
             }
-        except Conversation.DoesNotExist:
+        except Text.DoesNotExist:
             return {
                 "status_code": 404,
                 "message": f"找不到 text_uid = {text_uid}"
@@ -171,7 +171,7 @@ class TextController:
                 "status_code": 200,
                 "message": "Text 刪除成功"
             }
-        except Conversation.DoesNotExist:
+        except Text.DoesNotExist:
             return {
                 "status_code": 404,
                 "message": f"找不到 text_uid = {text_uid}"

--- a/main/apps/metadata_mgt/services/UserController.py
+++ b/main/apps/metadata_mgt/services/UserController.py
@@ -7,7 +7,7 @@ import django.utils.timezone as timezone
 class UserController:
 
     @staticmethod
-    def create_user(user_name, user_password, user_email, user_role=None):
+    def create_user(user_uname, user_password, user_uemail, user_role=None):
         """
         創建新使用者。
         """
@@ -16,9 +16,9 @@ class UserController:
             hashed_password = make_password(user_password)
 
             user = User(
-                user_name=user_name,
+                user_uname=user_uname,
                 user_password=hashed_password,
-                user_email=user_email,
+                user_uemail=user_uemail,
                 user_role=user_role
             )
             user.save()
@@ -54,23 +54,22 @@ class UserController:
             }
 
     @staticmethod
-    def login_user(username, userpassword):
+    def login_user(user_uname, user_password):
         """
         使用者登入邏輯：
-          1. 根據 username 查詢使用者
+          1. 根據 user_uname 查詢使用者
           2. 驗證密碼
           3. 更新最後登入時間
           4. 回傳結果
         """
         try:
-            # 1) 根據 username 取出使用者 (若 Model 欄位叫 user_name，就用 user_name=username)
-            user = User.objects.get(user_name=username)
+            # 1) 根據 user_uname 取出使用者 (若 Model 欄位叫 user_name，就用 user_uname=user_uname)
+            user = User.objects.get(user_uname=user_uname)
             
             # 2) 驗證密碼 (若 user_password 內存放的是加密後的密碼，需用 check_password)
-            if not check_password(userpassword, user.user_password):
+            if not check_password(user_password, user.user_password):
                 return {
                     "status_code": 400,
-                    "status": False,
                     "message": "Invalid password"
                 }
             
@@ -81,8 +80,7 @@ class UserController:
             # 4) 回傳成功資訊
             return {
                 "status_code": 200,
-                "status": True,
-                "message": "Login successful",
+                "message": "使用者登入成功",
                 "data": {
                     "user_uid": str(user.user_uid),
                     "last_login_time": (
@@ -96,46 +94,41 @@ class UserController:
             # 找不到使用者
             return {
                 "status_code": 404,
-                "status": False,
-                "message": "User does not exist"
+                "message": f"找不到 User"
             }
 
         except Exception as e:
             # 其他預期外錯誤
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"Server Error: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
-    def get_user_by_name(user_name):
+    def get_user_by_name(user_uname):
         """
-        根據 user_name 獲取使用者。
+        根據 user_uname 獲取使用者。
         """
         try:
-            user = User.objects.get(user_name=user_name)
+            user = User.objects.get(user_uname=user_uname)
             return {
                 "status_code": 200,
-                "status": True,
                 "message": (
                     f"使用者查詢成功 "
-                    f"(ID={user.user_id}, name={user.user_name}, email={user.user_email})"
+                    f"(ID={user.user_id}, name={user.user_uname}, email={user.user_uemail})"
                 )
             }
 
         except ObjectDoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": "使用者不存在"
+                "message": f"找不到 User"
             }
 
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
 
@@ -153,29 +146,25 @@ class UserController:
 
             return {
                 "status_code": 200,
-                "status": True,
                 "message": f"使用者更新成功"
             }
 
         except ObjectDoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": "使用者不存在"
+                "message": f"找不到 User"
             }
 
         except ValidationError as e:
             return {
                 "status_code": 400,
-                "status": False,
                 "message": f"驗證失敗: {e.message_dict}"
             }
 
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
 
@@ -189,20 +178,17 @@ class UserController:
             user.delete()
             return {
                 "status_code": 200,
-                "status": True,
-                "message": f"使用者已刪除 (ID={user_uid})"
+                "message": "使用者刪除成功"
             }
 
         except ObjectDoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
-                "message": "使用者不存在"
+                "message": f"找不到 User"
             }
 
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }

--- a/main/apps/metadata_mgt/services/WorkflowController.py
+++ b/main/apps/metadata_mgt/services/WorkflowController.py
@@ -22,7 +22,6 @@ class WorkflowController:
             if hasattr(conversation_obj, 'workflow'):
                 return {
                     "status_code": 400,
-                    "status": False,
                     "message": "該 Conversation 已有 Workflow，不可重複建立 (一對一限制)"
                 }
 
@@ -38,7 +37,6 @@ class WorkflowController:
 
             return {
                 "status_code": 201,
-                "status": True,
                 "message": "Workflow 建立成功",
                 "data": {
                     "workflow_id": workflow.workflow_id
@@ -48,27 +46,23 @@ class WorkflowController:
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "指定的 Conversation 不存在，無法建立 Workflow"
             }
         except IntegrityError as e:
             # 若 DB 已存在該 conversation_uid 的 workflow，unique constraint 會報錯
             return {
                 "status_code": 400,
-                "status": False,
                 "message": f"建立失敗，該 Conversation 已綁定 Workflow 或其他資料庫錯誤: {str(e)}"
             }
         except ValidationError as e:
             return {
                 "status_code": 400,
-                "status": False,
                 "message": f"驗證失敗: {e.message_dict}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -84,7 +78,6 @@ class WorkflowController:
 
             return {
                 "status_code": 200,
-                "status": True,
                 "message": "查詢 Workflow 成功",
                 "data": {
                     "workflow_id": workflow.workflow_id,
@@ -98,20 +91,17 @@ class WorkflowController:
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "指定的 Conversation 不存在"
             }
         except Workflow.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "尚未為該 Conversation 建立 Workflow"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -132,39 +122,33 @@ class WorkflowController:
             workflow.save()
             return {
                 "status_code": 200,
-                "status": True,
                 "message": "Workflow 更新成功"
             }
 
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "指定的 Conversation 不存在"
             }
         except Workflow.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "尚未為該 Conversation 建立 Workflow"
             }
         except IntegrityError as e:
             return {
                 "status_code": 400,
-                "status": False,
                 "message": f"更新失敗: {str(e)}"
             }
         except ValidationError as e:
             return {
                 "status_code": 400,
-                "status": False,
                 "message": f"驗證失敗: {e.message_dict}"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }
 
     @staticmethod
@@ -179,25 +163,21 @@ class WorkflowController:
             workflow.delete()
             return {
                 "status_code": 200,
-                "status": True,
                 "message": f"Workflow 已刪除 (conversation_uid={conversation_uid})"
             }
 
         except Conversation.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "指定的 Conversation 不存在"
             }
         except Workflow.DoesNotExist:
             return {
                 "status_code": 404,
-                "status": False,
                 "message": "尚未為該 Conversation 建立 Workflow"
             }
         except Exception as e:
             return {
                 "status_code": 500,
-                "status": False,
-                "message": f"伺服器內部錯誤: {str(e)}"
+                "message": f"系統發生錯誤: {str(e)}"
             }

--- a/main/apps/topic_mgt/actors/Broker.py
+++ b/main/apps/topic_mgt/actors/Broker.py
@@ -54,7 +54,7 @@ class Broker(AsyncWebsocketConsumer):
                     "message": f"Fail to call metadata_mgt API (verify_conversation_exist): {str(e)}"
                 }, status=502)
             
-            if not meta_data.get("status", False):
+            if not meta_data.get("status_code", 400):
                 return JsonResponse(meta_data, status=meta_data.get("status_code", 400))
             
 			# (3) 註冊 topic

--- a/main/apps/workflow_mgt/actors/Consumer.py
+++ b/main/apps/workflow_mgt/actors/Consumer.py
@@ -1,5 +1,5 @@
 from channels.generic.websocket import AsyncConsumer
-from main.utils.ApiKit import  json_request
+from main.utils.ApiKit import  json_request_async
 from main.utils.logger import async_log_writer
 
 class Consumer(AsyncConsumer):
@@ -12,6 +12,14 @@ class Consumer(AsyncConsumer):
         2. 呼叫 WorkflowManager.execute_workflow
         """
 
+        await async_log_writer(
+            log_level="INFO",
+            status_code="200",
+            source_type="Websocket",
+            func=self.send_message,
+            args=[self],
+            message="WebSocket send_message receive"
+        )
         # (1) 檢查必填欄位
         payload = event.get("payload", {})
         required_fields = ["conversation_uid", "text_content"]
@@ -27,7 +35,7 @@ class Consumer(AsyncConsumer):
         conversation_uid = payload["conversation_uid"]
         text_content = payload["text_content"]
         workflow_payload = {"conversation_uid": conversation_uid, "text_content": text_content}
-        json_request(
+        resp = await json_request_async(
             module="workflow_mgt",
             actor="WorkflowManager",
             function="execute_workflow",
@@ -40,7 +48,7 @@ class Consumer(AsyncConsumer):
             source_type="Websocket",
             func=self.send_message,
             args=[self],
-            message="WebSocket send_message success"
+            message=f"WebSocket send_message success:"
         )
 
         return

--- a/main/apps/workflow_mgt/actors/WorkflowManager.py
+++ b/main/apps/workflow_mgt/actors/WorkflowManager.py
@@ -67,12 +67,12 @@ class WorkflowManager:
 
             # (2) 呼叫 dify 執行工作流
             result = dify_single_intent_workflow(conversation_uid, user_content)
-            if not result or "parsed_data" not in result:
+            if not result or "data" not in result:
                 return JsonResponse({
                     "status_code": 502,
                     "message": "Failed execute workflow."
                 }, status=502)
-            text_data = result.get("parsed_data","")
+            text_data = result.get("data","")
 
             return JsonResponse({
                 "status_code": 200,
@@ -133,7 +133,7 @@ class WorkflowManager:
                 }, status=502)
 
             # 檢查後端回傳是否成功
-            if not meta_data.get("status", False):
+            if not meta_data.get("status_code", 400):
                 return JsonResponse(meta_data, status_code=meta_data.get("status_code", 400))
 
             return JsonResponse({
@@ -170,7 +170,6 @@ class WorkflowManager:
             if missing_fields:
                 return JsonResponse({
                     "status_code": 400,
-                    "status": False,
                     "message": f"缺少必填欄位: {', '.join(missing_fields)}"
                 }, status=400)
 
@@ -185,11 +184,11 @@ class WorkflowManager:
 
             # 最後回傳 HTTP 結果
             return JsonResponse({
-                "status": True,
+                "status_code": 200,
                 "message": "Logger Human in the loop processed successfully",
             }, status=200)
 
         except json.JSONDecodeError:
-            return JsonResponse({"status": False, "message": "Invalid JSON"}, status=400)
+            return JsonResponse({"status_code": 400, "message": "Invalid JSON"}, status=400)
         except Exception as e:
-            return JsonResponse({"status": False, "message": str(e)}, status=500)
+            return JsonResponse({"status_code": 500, "message": str(e)}, status=500)

--- a/main/apps/workflow_mgt/services/workflows.py
+++ b/main/apps/workflow_mgt/services/workflows.py
@@ -263,35 +263,35 @@ def dify_single_intent_workflow(conversation_uid,user_prompt):
                 print("推播失敗:", e)
 
             return {
-                "status": True,
+                "status_code": 200,
                 "message": "成功取得資料",
-                "parsed_data": ans_text,             # 可依需求改變資料結構
+                "data": ans_text,             # 可依需求改變資料結構
             }
         else:
             # 如果根本沒有解析到 workflow_finished_data
             return {
-                "status": False,
+                "status_code": 404,
                 "message": "未找到 workflow_finished 事件",
-                "parsed_data": None,
+                "data": None,
             }
 
     except requests.exceptions.Timeout as e:
         return {
-            "status": False,
+            "status_code": 500,
             "message": f"Request Timeout: {str(e)}",
-            "parsed_data": None
+            "data": None
         }
     except requests.exceptions.RequestException as e:
         # 包含所有 requests 模組可能出現的網路錯誤 (ConnectionError, HTTPError 等)
         return {
-            "status": False,
+            "status_code": 500,
             "message": f"HTTP/Network Error: {str(e)}",
-            "parsed_data": None
+            "data": None
         }
     except Exception as e:
         # 其他非 requests 相關的意外錯誤
         return {
-            "status": False,
+            "status_code": 500,
             "message": f"Unexpected Error: {str(e)}",
-            "parsed_data": None
+            "data": None
         }


### PR DESCRIPTION
## 🚀 目的 / Motivation
為了 **對齊文件和實作規格**，本次 PR：
1. 將實作對齊文件
2. 統一用 status_code 作為 API 狀態回覆
3. 修正 User table 欄位


## 📝 主要變更 / What’s Changed
- **status_code**
  - 移除 status，統一用 status_code 作為 API 狀態回覆
  
- **User table**
  - 修改 username, password, email 為 user_uname, user_password, user_uemail


## ✅ 如何測試 / How to Test
1. 確保 `itri-net` 已存在，不存在則執行
`docker network create itri-net`

2. 新增腳本 `run_all.sh`
    ```shell
    #!/bin/bash
    
    # 宣告 network
    NETWORK=itri-net
    IMAGE=itri-intent-backend
    
    function remove_container_if_exists() {
      local container_name="$1"
      if [ "$(docker ps -aq -f name=${container_name})" ]; then
        echo "Stopping and removing existing container: ${container_name}"
        docker stop "${container_name}" 2>/dev/null
        docker rm "${container_name}" 2>/dev/null
      fi
    }
    
    function remove_image_if_exists () {
      local image="$1"
      if docker images -q "${image}" | grep -q .; then
        echo "Removing old image ${image}"
        docker rmi -f "${image}" >/dev/null
      fi
    }
    
    remove_container_if_exists "itri-intent-backend"
    remove_container_if_exists "itri-intent-worker"
    remove_container_if_exists "intent-postgres-db"
    remove_container_if_exists "intent-redis-db"
    remove_container_if_exists "intent-pgadmin"
    remove_image_if_exists "${IMAGE}"
    
    
    source .env
    
    # 啟動 Postgres 容器
    docker run --network $NETWORK --name intent-postgres-db \
        -e POSTGRES_PASSWORD=$HTTP_POSTGRES_DATABASE_PASSWORD \
        -e POSTGRES_USER=$HTTP_POSTGRES_DATABASE_HOST_USER \
        -p $HTTP_POSTGRES_DATABASE_HOST_PORT:$HTTP_POSTGRES_DATABASE_HOST_PORT \
        -v ~/postgres_data:/var/lib/postgresql/data \
        -d postgres:latest
    
    sleep 5
    
    # 建立資料庫
    docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -c "CREATE DATABASE intent;"
    
    # 檢查資料庫列表
    # docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -l
    
    # 啟動 pgAdmin 容器
    docker run --network $NETWORK --name intent-pgadmin \
        -e PGADMIN_DEFAULT_EMAIL=$HTTP_PGADMIN_EMAIL \
        -e PGADMIN_DEFAULT_PASSWORD=$HTTP_PGADMIN_PASSWORD \
        -p $HTTP_PGADMIN_HOST_PORT:80 \
        -d dpage/pgadmin4
      
    #啟動 Redis 容器 
    docker run --network $NETWORK --name intent-redis-db \
      -e REDIS_USER=$HTTP_REDIS_DATABASE_HOST_USER \
      -e REDIS_PASSWORD=$HTTP_REDIS_DATABASE_PASSWORD \
      -p $HTTP_REDIS_DATABASE_HOST_PORT:$HTTP_REDIS_DATABASE_HOST_PORT \
      -d redis \
      sh -c 'echo "databases 16" > /tmp/redis.conf && \
             echo "user $REDIS_USER on >$REDIS_PASSWORD ~* +@all" >> /tmp/redis.conf && \
             redis-server /tmp/redis.conf'
             
    #包專案image
    docker build --no-cache -t itri-intent-backend ./
    
    # 啟動 意圖後端系統 容器
    docker run -d --network $NETWORK \
        --name itri-intent-backend \
        -p $HTTP_WORKFLOW_MGT_PORT:$HTTP_WORKFLOW_MGT_PORT \
        itri-intent-backend \
        sh -c "
          python manage.py migrate --noinput &&
          daphne -b 0.0.0.0 -p $HTTP_WORKFLOW_MGT_PORT main.asgi:application
        "
    
    # 啟動 意圖後端系統 Channels Worker 監聽 ChannelNameRouter
    docker run -d --network $NETWORK \
      --name itri-intent-worker \
      --env-file .env \
      itri-intent-backend \
      bash -c "source .env && python manage.py runworker consumer"
    ```

4. 跑佈署腳本
    ```shell
	chmod 777 run.sh
    ./run_all.sh
	```

5. 如果遇到 `/media` 權限問題，需手動設定權限


## 📜 測試項目 / Test Case

### 從前端操作須符合

1. 註冊
2. 登入
4. 獲取對話清單
5. 創建對話，並會自動生成標題
	- 輸入文本`查詢整體UE狀態`需顯示表格
	- 輸入文本`查詢SINR Map`需顯示圖片
	- 輸入文本`預測干擾抑制演算法`需顯示表格
	- 輸入文本`執行干擾抑制演算法`需顯示表格
	- 輸入文本`停用干擾抑制演算法`需顯示表格
6. 修改對話名稱
7. 刪除對話


### 從後端操作須符合

1. 正常解析不同來源，包括`system`, `Websocket`, `dify engine`
2. 狀態碼解析正常，不會出現定義之外狀況
3. 錯誤訊息能正常顯示
5. 正常記錄所有執行動作
6. 創建對話，redis 有相關紀錄，workflow_status 紀錄為 `1`
7. dify 處理時，workflow_status 紀錄為 `2`
8. dify 處理結束回傳前端後，workflow_status 紀錄為 `3`
9. 刪除對話，redis 不會有該 topic 存在


## 📷 螢幕截圖 / Demo
<img width="1903" height="901" alt="image" src="https://github.com/user-attachments/assets/e69d9bb0-9631-4866-a897-15626e67b37b" />
