### PR TITLE
Feature/yihua/fix conversation name language

### DIFF
--- a/main/apps/conversation_mgt/services/ConversationKit.py
+++ b/main/apps/conversation_mgt/services/ConversationKit.py
@@ -46,7 +46,7 @@ def call_gemini_api_for_title(prompt: str, model_name: str = "gemini-1.5-flash")
 def generate_conversation_title(
     user_prompt: str,
     api_backend: Callable[[str, str], str] = call_openai_api_for_title,
-    model_name: str = "gpt-4o"
+    model_name: str = "gpt-4o-mini"
 ) -> str:
     """
     根據使用者提問，呼叫指定的 API 後端來生成對話標題。
@@ -64,21 +64,16 @@ def generate_conversation_title(
     # 建立一個專門用於生成標題的提示 (Prompt)，要求以 JSON 格式輸出
     title_generation_prompt = f"""
 ### 角色 ###
-你是一個標題生成器。請根據使用者輸入，產生一個簡潔、準確的標題，並且**輸出的語言必須與使用者輸入的主要語言完全相同**。
+你是一個標題生成器。請根據使用者輸入，產生一個簡潔、準確的英文標題。
 
 ### 任務說明 ###
-1. 閱讀使用者輸入，判斷主要語言（中文或英文），禁止將輸入內容翻譯成另一種語言。
-2. 若輸入內容主要為中文，則標題必須完全用中文生成；若主要為英文，則標題必須完全用英文生成。
-3. 對輸入文字進行大小寫不敏感的全域檢查（需跨行），判斷是否屬於「無線網路管理」相關內容：
-   - 關鍵詞包含（忽略大小寫與換行）：  
-     - 中文：無線網路、基站、干擾抑制  
-     - 英文：UE、SINR MAP、Interference suppression
-4. 若輸入包含上述任何關鍵詞（不分大小寫與換行），則根據輸入內容生成 5 到 10 個字的標題（保持輸入語言）。
-5. 若輸入內容與「無線網路管理」無關（如問候語、天氣、閒聊等），輸出以下預設標題（保持輸入語言）：  
-   - 中文輸入 → 「ITRI網路服務」  
-   - 英文輸入 → "ITRI Network Service"
-6. 在輸出前，必須檢查標題的語言與輸入的主要語言完全一致。
-7. 將生成的標題封裝在一個 JSON 物件中。
+1. 閱讀使用者輸入。
+2. 對輸入內容進行大小寫不敏感的全域檢查，判斷是否包含「無線網路管理」相關關鍵詞：
+   - 關鍵詞（忽略大小寫）：無線網路、基站、干擾抑制、UE status、SINR MAP、Interference suppression
+3. 根據關鍵詞判斷結果，決定如何生成標題：
+   - 若輸入包含任何關鍵詞，生成一個 5 到 10 個字的英文標題。
+   - 若輸入不包含任何關鍵詞，輸出預設標題："ITRI Network Service"。
+4. 將生成的標題封裝在一個 JSON 物件中。
 
 ### 輸出格式 ###
 你必須嚴格按照以下 JSON 格式輸出，不要包含任何其他文字、說明或 Markdown 語法。


### PR DESCRIPTION
## 🚀 目的 / Motivation
為了 **根據文本語言產生對應標題**，本次 PR：
1. 修改生成對話標題成英文


## 📝 主要變更 / What’s Changed
- **ConversationKit.py**
  - 修改 prompt
  - 修改 OpenAI model 3.5 成 4o-mini


## ✅ 如何測試 / How to Test
1. 確保 `itri-net` 已存在，不存在則執行
`docker network create itri-net`

2. 新增腳本 `run_all.sh`
    ```shell
    #!/bin/bash
    
    # 宣告 network
    NETWORK=itri-net
    IMAGE=itri-intent-backend
    
    function remove_container_if_exists() {
      local container_name="$1"
      if [ "$(docker ps -aq -f name=${container_name})" ]; then
        echo "Stopping and removing existing container: ${container_name}"
        docker stop "${container_name}" 2>/dev/null
        docker rm "${container_name}" 2>/dev/null
      fi
    }
    
    function remove_image_if_exists () {
      local image="$1"
      if docker images -q "${image}" | grep -q .; then
        echo "Removing old image ${image}"
        docker rmi -f "${image}" >/dev/null
      fi
    }
    
    remove_container_if_exists "itri-intent-backend"
    remove_container_if_exists "itri-intent-worker"
    remove_container_if_exists "intent-postgres-db"
    remove_container_if_exists "intent-redis-db"
    remove_container_if_exists "intent-pgadmin"
    remove_image_if_exists "${IMAGE}"
    
    
    source .env
    
    # 啟動 Postgres 容器
    docker run --network $NETWORK --name intent-postgres-db \
        -e POSTGRES_PASSWORD=$HTTP_POSTGRES_DATABASE_PASSWORD \
        -e POSTGRES_USER=$HTTP_POSTGRES_DATABASE_HOST_USER \
        -p $HTTP_POSTGRES_DATABASE_HOST_PORT:$HTTP_POSTGRES_DATABASE_HOST_PORT \
        -v ~/postgres_data:/var/lib/postgresql/data \
        -d postgres:latest
    
    sleep 5
    
    # 建立資料庫
    docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -c "CREATE DATABASE intent;"
    
    # 檢查資料庫列表
    # docker exec -it intent-postgres-db psql -U $HTTP_POSTGRES_DATABASE_HOST_USER -l
    
    # 啟動 pgAdmin 容器
    docker run --network $NETWORK --name intent-pgadmin \
        -e PGADMIN_DEFAULT_EMAIL=$HTTP_PGADMIN_EMAIL \
        -e PGADMIN_DEFAULT_PASSWORD=$HTTP_PGADMIN_PASSWORD \
        -p $HTTP_PGADMIN_HOST_PORT:80 \
        -d dpage/pgadmin4
      
    #啟動 Redis 容器 
    docker run --network $NETWORK --name intent-redis-db \
      -e REDIS_USER=$HTTP_REDIS_DATABASE_HOST_USER \
      -e REDIS_PASSWORD=$HTTP_REDIS_DATABASE_PASSWORD \
      -p $HTTP_REDIS_DATABASE_HOST_PORT:$HTTP_REDIS_DATABASE_HOST_PORT \
      -d redis \
      sh -c 'echo "databases 16" > /tmp/redis.conf && \
             echo "user $REDIS_USER on >$REDIS_PASSWORD ~* +@all" >> /tmp/redis.conf && \
             redis-server /tmp/redis.conf'
             
    #包專案image
    docker build --no-cache -t itri-intent-backend ./
    
    # 啟動 意圖後端系統 容器
    docker run -d --network $NETWORK \
        --name itri-intent-backend \
        -p $HTTP_WORKFLOW_MGT_PORT:$HTTP_WORKFLOW_MGT_PORT \
        itri-intent-backend \
        sh -c "
          python manage.py migrate --noinput &&
          python manage.py runserver 0.0.0.0:$HTTP_WORKFLOW_MGT_PORT
        "
    
    # 啟動 意圖後端系統 Channels Worker 監聽 ChannelNameRouter
    docker run -d --network $NETWORK \
      --name itri-intent-worker \
      --env-file .env \
      itri-intent-backend \
      bash -c "source .env && python manage.py runworker consumer"
    ```

4. 跑佈署腳本
    ```shell
	chmod 777 run.sh
    ./run_all.sh
	```

5. 如果遇到 `/media` 權限問題，需手動設定權限


## 📜 測試項目 / Test Case

### 從前端操作須符合

1. 註冊
2. 登入
4. 獲取對話清單
5. 創建對話，並會自動生成標題
    - 意圖檢查
		- 輸入文本`查詢整體UE狀態`需顯示表格
		- 輸入文本`查詢SINR Map`需顯示圖片
		- 輸入文本`預測干擾抑制演算法`需顯示表格
		- 輸入文本`執行干擾抑制演算法`需顯示表格
		- 輸入文本`停用干擾抑制演算法`需顯示表格
	- 對話名稱檢查
		- 輸入文本`hi`，對話標題是`ITRI Network Service`
		- 輸入文本`今天天氣如何`，對話標題是`ITRI Network Service`
		- 輸入文本`get sinr map`，對話標題不會是`ITRI Network Service`
		- 輸入文本`查詢UE狀態`，對話標題不會是`ITRI Network Service`
6. 修改對話名稱
7. 刪除對話


### 從後端操作須符合

1. 正常解析不同來源，包括`system`, `Websocket`, `dify engine`
2. 狀態碼解析正常，不會出現定義之外狀況
3. 錯誤訊息能正常顯示
5. 正常記錄所有執行動作
6. 創建對話，redis 有相關紀錄，workflow_status 紀錄為 `1`
7. dify 處理時，workflow_status 紀錄為 `2`
8. dify 處理結束回傳前端後，workflow_status 紀錄為 `3`
9. 刪除對話，redis 不會有該 topic 存在


## 📷 螢幕截圖 / Demo
<img width="1909" height="888" alt="image" src="https://github.com/user-attachments/assets/1971a260-733c-40a1-b80d-dcd974460a78" />